### PR TITLE
Update for  Laravel 4.2

### DIFF
--- a/src/Khill/Lavacharts/Lavacharts.php
+++ b/src/Khill/Lavacharts/Lavacharts.php
@@ -1,6 +1,6 @@
 <?php namespace Khill\Lavacharts;
 
-use Illuminate\View\Environment;
+use Illuminate\View\Factory;
 use Illuminate\Config\Repository;
 use Khill\Lavacharts\Configs\jsDate;
 use Khill\Lavacharts\Configs\textStyle;
@@ -137,7 +137,7 @@ class Lavacharts
      * @param  Illuminate\Config\Repository  $config
      * @return void
      */
-    public function __construct(Environment $view, Repository $config)
+    public function __construct(Factory $view, Repository $config)
     {
         $this->view   = $view;
         $this->config = $config;


### PR DESCRIPTION
Once Laravel is updated to 4.2, you will get the following error running LavaCharts:

Argument 1 passed to Khill\Lavacharts\Lavacharts::__construct() must be an instance of Khill\Lavacharts\Environment, instance of Illuminate\View\Factory given

Simple fix, maybe create a branch for laravel 4.2?

Thanks!
