### PR TITLE
Make Changes for adding and firing events

### DIFF
--- a/src/Khill/Lavacharts/Charts/Chart.php
+++ b/src/Khill/Lavacharts/Charts/Chart.php
@@ -296,7 +296,7 @@ class Chart
 
         if (is_array($e)) {
             foreach ($e as $event) {
-                if (is_subclass_of($event, 'Lavacharts\Events\Event')) {
+                if (is_subclass_of($event, 'Khill\Lavacharts\Events\Event')) {
                     $this->events[] = $event;
                 } else {
                     throw $this->invalidConfigValue(

--- a/src/Khill/Lavacharts/JavascriptFactory.php
+++ b/src/Khill/Lavacharts/JavascriptFactory.php
@@ -181,11 +181,12 @@ class JavascriptFactory
             $out .= $this->buildFormatters();
         }
 
-        $out .= '$this.chart.draw($this.data, $this.options);'.PHP_EOL;
-
         if ($this->chart->hasEvents()) {
             $out .= $this->buildEventCallbacks();
         }
+
+        $out .= '$this.chart.draw($this.data, $this.options);'.PHP_EOL;
+
 
         $out .= "};".PHP_EOL.PHP_EOL;
 


### PR DESCRIPTION
There are two problems which I faced:

```
$ready = new \Khill\Lavacharts\Events\Ready('readyCallBack');

$linechart->events([$ready]);
```
This was throwing an error because of namespacing problem. `is_subclass_of($event, '\Lavacharts\Events\Event')` returns false.

2nd Problem:

Registering for events like 'ready' show be done before calling draw. So I have just shifted the position to before draw during render.


