### PR TITLE
Resolve issue with multiple charts of single type on a page

### DIFF
--- a/src/Khill/Lavacharts/JavascriptFactory.php
+++ b/src/Khill/Lavacharts/JavascriptFactory.php
@@ -136,7 +136,7 @@ class JavascriptFactory
         /*
          *  If the object does not exist for a given chart type, initialise it.
          *  This will prevent overriding keys when multiple charts of the same
-         *  type are being rendered on the same page
+         *  type are being rendered on the same page.
          */
         $out .= sprintf(
             'if ( typeof lava.charts.%1$s == "undefined" ) { lava.charts.%1$s = {}; }',

--- a/src/Khill/Lavacharts/JavascriptFactory.php
+++ b/src/Khill/Lavacharts/JavascriptFactory.php
@@ -143,7 +143,7 @@ class JavascriptFactory
         //Checking if output div exists
         $out .= sprintf(
             'if (!document.getElementById("%s"))' .
-            '{console.error("[Lavaharts] No matching element was found with ID \"%s\"");}',
+            '{console.error("[Lavacharts] No matching element was found with ID \"%s\"");}',
             $this->elementId,
             $this->elementId
         ).PHP_EOL.PHP_EOL;

--- a/src/Khill/Lavacharts/JavascriptFactory.php
+++ b/src/Khill/Lavacharts/JavascriptFactory.php
@@ -133,9 +133,19 @@ class JavascriptFactory
     {
         $out = $this->jsO.PHP_EOL;
 
+        /*
+         *  If the object does not exist for a given chart type, initialise it.
+         *  This will prevent overriding keys when multiple charts of the same
+         *  type are being rendered on the same page
+         */
+        $out .= sprintf(
+            'if ( typeof lava.charts.%1$s == "undefined" ) { lava.charts.%1$s = {}; }',
+            $this->chart->type
+        ).PHP_EOL.PHP_EOL;
+
         //Creating new chart js object
         $out .= sprintf(
-            'lava.charts.%s = {"%s":{chart:null,draw:null,data:null,options:null,formats:[]}};',
+            'lava.charts.%s.%s = {chart:null,draw:null,data:null,options:null,formats:[]};',
             $this->chart->type,
             $this->chart->label
         ).PHP_EOL.PHP_EOL;

--- a/src/Khill/Lavacharts/JavascriptFactory.php
+++ b/src/Khill/Lavacharts/JavascriptFactory.php
@@ -145,7 +145,7 @@ class JavascriptFactory
 
         //Creating new chart js object
         $out .= sprintf(
-            'lava.charts.%s.%s = {chart:null,draw:null,data:null,options:null,formats:[]};',
+            'lava.charts.%s["%s"] = {chart:null,draw:null,data:null,options:null,formats:[]};',
             $this->chart->type,
             $this->chart->label
         ).PHP_EOL.PHP_EOL;


### PR DESCRIPTION
This appears to have been caused by variables bubbling up, causing the last created chart to override all before it, resulting in undefined charts.