### PR TITLE
set timezone based PHP timezone

### DIFF
--- a/src/Khill/Lavacharts/Configs/DataTable.php
+++ b/src/Khill/Lavacharts/Configs/DataTable.php
@@ -103,17 +103,22 @@ class DataTable
     public function __construct($timezone=null)
     {
         $this->setTimezone($timezone);
-
-        date_default_timezone_set($this->timezone);
     }
 
     public function setTimezone($timezone)
     {
+        // get PHP.ini setting
+        $default_timezone = date_default_timezone_get();
+        
         if (Utils::nonEmptyString($timezone)) {
             $this->timezone = $timezone;
+        } elseif (Utils::nonEmptyString($default_timezone)) {
+            $this->timezone = $default_timezone;
         } else {
             $this->timezone = 'America/Los_Angeles';
         }
+        
+        date_default_timezone_set($this->timezone);
 
         return $this;
     }


### PR DESCRIPTION
If constructor using null, then get PHP timezone default setting.
If PHP timezone default setting is null (or not defined), then setting "America/Los_Angeles".
Plus setTimezone() function set to PHP timezone.
(sorry for bad english)