### PR TITLE
Don't assume dateTimeFormat is not null to avoid throwing InvalidDate…

### DIFF
--- a/src/DataTables/Rows/RowFactory.php
+++ b/src/DataTables/Rows/RowFactory.php
@@ -80,7 +80,11 @@ class RowFactory
                 if ($cell instanceof Carbon) {
                     $rowData[] = new DateCell($cell);
                 } else {
-                    $rowData[] = DateCell::parseString($cell, $dateTimeFormat);
+    		    if (isset($dateTimeFormat)) {
+                        $rowData[] = DateCell::parseString($cell, $dateTimeFormat);
+                    } else {
+                        $rowData[] = DateCell::parseString($cell);
+                    }
                 }
             } else {
                 $rowData[] = $cell;


### PR DESCRIPTION
Don't assume dateTimeFormat is not null to avoid throwing InvalidDateTimeFormat in DateCell.php parseString().  See also https://github.com/kevinkhill/lavacharts/issues/69.