### PR TITLE
Added support for formatting at a cell level

### DIFF
--- a/src/Configs/DataTable.php
+++ b/src/Configs/DataTable.php
@@ -375,7 +375,11 @@ class DataTable
                         if ($this->cols[$index]['type'] == 'date') {
                             $rowVals[] = array('v' => $this->parseDate($optCellArray[$index]));
                         } else {
-                            $rowVals[] = array('v' => $optCellArray[$index]);
+                            if(is_object($optCellArray[$index])) {
+                                $rowVals[] = array('v' => $optCellArray[$index]->v,'f' => $optCellArray[$index]->f,'p' => $optCellArray[$index]->p);
+                            } else {
+                                $rowVals[] = array('v' => $optCellArray[$index]);
+                            }
                         }
                     } else {
                         $rowVals[] = array('v' => null);


### PR DESCRIPTION
Added support for formatting at a cell level, using “v”, “f” and “p”
parameters, in this order.
Example:
$chart->addRow(array(2015, new DataCell(0.8,'80%')));