### PR TITLE
Change reference to jsapi to include 'https:'

### DIFF
--- a/javascript/lava.js
+++ b/javascript/lava.js
@@ -248,7 +248,7 @@ var lava = lava || {};
   this.run = function (window) {
     var s = document.createElement('script');
     s.type = 'text/javascript';
-    s.src = '//www.google.com/jsapi';
+    s.src = 'https://www.google.com/jsapi';
     s.onload = s.onreadystatechange = function (event) {
       event = event || window.event;
 


### PR DESCRIPTION
wkhtmltopdf does not allow invalid references to resources, changing s.src to 'https://www.google.com/jsapi' enables the PDF generator to successfuly render.

Not sure how this impacts normal browser use?