### PR TITLE
Fix isValidTimeZone under MacOS X

### DIFF
--- a/src/DataTables/DataTable.php
+++ b/src/DataTables/DataTable.php
@@ -757,14 +757,14 @@ class DataTable implements Jsonable, JsonSerializable
 
         $timezones = array_map(function ($timezone) {
             if ($timezone['timezone_id'] != null) {
-                return $timezone['timezone_id'];
+                return strtolower($timezone['timezone_id']);
             }
         }, $timezoneList);
 
         $timezones = array_filter($timezones, 'is_string');
         $timezones = array_unique($timezones);
 
-        return in_array($tz, $timezones, true);
+        return in_array(strtolower($tz), $timezones, true);
     }
 
 }


### PR DESCRIPTION
On my MacOS X PHP 7.0.19 the call to date_default_timezone_get() returns etc/UTC but the isValidTimeZone function uses in_array to search for the timezone but as this is a string in_array does a case sensitive search which fails as PHP reports this timezone as etc/UTC.