### PR TITLE
Fix "Is not a valid Timezone"

### DIFF
--- a/src/DataTables/DataTable.php
+++ b/src/DataTables/DataTable.php
@@ -757,16 +757,8 @@ class DataTable implements Jsonable, JsonSerializable
             return false;
         }
 
-        $timezoneList = call_user_func_array('array_merge', timezone_abbreviations_list());
-
-        $timezones = array_map(function ($timezone) {
-            if ($timezone['timezone_id'] != null) {
-                return strtolower($timezone['timezone_id']);
-            }
-        }, $timezoneList);
-
-        $timezones = array_filter($timezones, 'is_string');
-        $timezones = array_unique($timezones);
+        $timezones = timezone_identifiers_list();
+        $timezones = array_map('strtolower',$timezones);
 
         return in_array(strtolower($tz), $timezones, true);
     }


### PR DESCRIPTION
Lavachart is using listAbbreviations method to check timezone, the recomendation is to use listIdentifiers method instead.

Related Issue:
[Lavachart america/sao_paulo is not a valid timezone #256](https://github.com/kevinkhill/lavacharts/issues/256#)