### PR TITLE
Use quotes for parameters (mandatory in symfony 4+)

### DIFF
--- a/src/Symfony/Bundle/Resources/config/services.yml
+++ b/src/Symfony/Bundle/Resources/config/services.yml
@@ -4,10 +4,10 @@ parameters:
 
 services:
     lavacharts:
-        class: %khill.lavacharts.class%
+        class: "%khill.lavacharts.class%"
 
     lavacharts.twig_extension:
-        class: %khill.lavacharts.twig%
+        class: "%khill.lavacharts.twig%"
         public: false
         arguments: ['@lavacharts']
         tags:


### PR DESCRIPTION
Quote parameters in ther service.yml file, as required by Symfony 4 and onwards.
This raises a deprecated message in Symfony 3, but fails in Symfony 4 (malformed yaml file)