### PR TITLE
Fix psr4 autoload warning

### DIFF
--- a/src/Support/Renderable.php
+++ b/src/Support/Renderable.php
@@ -20,7 +20,7 @@ use \Khill\Lavacharts\Support\Traits\ElementIdTrait as HasElementId;
  * @link       http://lavacharts.com                   Official Docs Site
  * @license    http://opensource.org/licenses/MIT MIT
  */
-class RenderableTrait
+class Renderable
 {
     use HasElementId;
 


### PR DESCRIPTION
composer gives warning while update. in some case, it does not add lavachart to autoloading due to this issue