### PR TITLE
Fix compatibility issues under PHP 8.1, which may cause opcache compilation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 3.1.10
+  - Fixed PHP 8.1 compatibility issues between `JavascriptDate` and `Carbon`, which may cause opcache compilation failures. 
+
 - 3.1.9
   - Fixing bug where using `setOptions` instead of the constructor skipped the processing of `png` and `material` attributes.
 
@@ -126,7 +129,7 @@
       - Called after all of the google jsapi is loaded and the charts are rendered.
 
 - 2.5.7
- - AJAX data loading bugfixes
+- AJAX data loading bugfixes
 
 - 2.5.6
   - Fixes for AJAX chart loading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- 3.1.10
+- 3.1.15
   - Fixed PHP 8.1 compatibility issues between `JavascriptDate` and `Carbon`, which may cause opcache compilation failures. 
 
 - 3.1.9

--- a/src/Laravel/LavachartsServiceProvider.php
+++ b/src/Laravel/LavachartsServiceProvider.php
@@ -25,6 +25,7 @@ class LavachartsServiceProvider extends ServiceProvider
 {
     protected $defer = true;
 
+    private string $configPath;
     private $configFile = 'lavacharts.php';
 
     /**

--- a/src/Support/JavascriptDate.php
+++ b/src/Support/JavascriptDate.php
@@ -9,9 +9,8 @@ class JavascriptDate extends Carbon
     /**
      * JavascriptDate constructor.
      */
-    public function __construct()
+    public function __construct($time = null, $tz = null)
     {
-        $tz   = null;
         $hour = null;
         $args = func_get_args();
 
@@ -41,7 +40,7 @@ class JavascriptDate extends Carbon
             $second = isset($args[5]) ? $args[5] : 0;
         }
 
-        return parent::__construct(sprintf('%s-%s-%s %s:%02s:%02s', $year, $month, $day, $hour, $minute, $second), $tz);
+        parent::__construct(sprintf('%s-%s-%s %s:%02s:%02s', $year, $month, $day, $hour, $minute, $second), $tz);
     }
 
 }


### PR DESCRIPTION
The `JavascriptDate` class included in this package has an incompatible constructor with its parent class, `Carbon`.

This won't cause issues prior to PHP 8.1 — and is unlikely to even affect those using 8.1 anyway, as the `JavascriptDate` class doesn't actually seem to be called anywhere in the package :)

However... If you try to pre-compile your application scripts with the PHP opcache, an `E_COMPILE_ERROR` is thrown, which can randomly cause your entire autoloader to break 🧨 (as I found out the hard way...). This is due to a PHP bug, which has only recently been fixed (https://github.com/php/php-src/issues/8164)

A new release tagged as `3.1.15` would be great. Thank you!